### PR TITLE
Publish mixin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+# Add your name to this file if you want to be automatically assign to pull requests
+# See OWNERS.md for a list of all maintainers
+
+*   @getporter/maintainers

--- a/.github/workflows/tofu-mixin.yml
+++ b/.github/workflows/tofu-mixin.yml
@@ -4,6 +4,10 @@ on:
    branches:
    - main
    - v*
+   tags:
+   - v*
+   - "!canary*"
+   - "!latest*"
  pull_request:
    branches:
    - main

--- a/.github/workflows/tofu-mixin.yml
+++ b/.github/workflows/tofu-mixin.yml
@@ -25,8 +25,8 @@ jobs:
      run: mage Test
    - name: Cross Compile
      run: mage XBuildAll
-#    - name: Publish
-#      if: success() && github.event_name != 'PullRequest'
-#      env:
-#        GITHUB_TOKEN: "${{ secrets.PUBLISH_TOKEN }}"
-#      run: mage Publish
+   - name: Publish
+     if: success() && github.event_name != 'PullRequest'
+     env:
+       GITHUB_TOKEN: "${{ secrets.PUBLISH_TOKEN }}"
+     run: mage Publish


### PR DESCRIPTION
- Uncomment publish job steps in GitHub Actions workflow
- Publish step runs on successful builds for non-PR events
- Uses PUBLISH_TOKEN secret for GitHub authentication
- Add CODEOWNERS

closes https://github.com/getporter/porter/issues/3038